### PR TITLE
scertecd: retry DNS creation probe errors more quickly

### DIFF
--- a/scertecd/scertecd.go
+++ b/scertecd/scertecd.go
@@ -1187,8 +1187,14 @@ func (s *Server) checkAWSPermissionsLoop() {
 		if err := s.checkAWSPermissions(); err != nil {
 			s.Logf("checkAWSPermissions error: %v", err)
 			s.addError(errTypeMakeRecord)
+
+			// If we failed to make a record, try again in a few minutes.
+			// This lets us distinguish between a transient error and a more
+			// persistent issue in alerting.
+			time.Sleep(10 * time.Minute)
+		} else {
+			time.Sleep(1 * time.Hour)
 		}
-		time.Sleep(1 * time.Hour)
 	}
 }
 


### PR DESCRIPTION
The default probe interval for DNS record creation is 1 hour.  If one fails,
even if it was some transient AWS thing, the possible successq will be an hour
later, and the last success will look stale.

This makes the probe alerts occasionally (slightly) noisy.  To mitigate that,
retry failures sooner.
