### PR TITLE
scertecd: log more detail of ACME failures

### DIFF
--- a/scertecd/scertecd.go
+++ b/scertecd/scertecd.go
@@ -752,7 +752,7 @@ func (cu *certUpdateCheck) finishACME(ctx context.Context, ci *acmeChallengeInfo
 			return nil, ctx.Err()
 		}
 		if oe, ok := err.(*acme.OrderError); ok {
-			cu.Logf("WaitOrder: OrderError status %q", oe.Status)
+			cu.Logf("WaitOrder: OrderError status %q; err=%s", oe.Status, oe.Error())
 		} else {
 			cu.Logf("WaitOrder error: %v", err)
 		}


### PR DESCRIPTION
Log more detailed error message from ACME challenge acceptance failures
for diagnosis.

Updates tailscale/corp#22985

Signed-off-by: Patrick O'Doherty <patrick@tailscale.com>