### PR TITLE
scertecd: add private certificate authority support

### DIFF
--- a/cmd/scertecd/scertecd-main.go
+++ b/cmd/scertecd/scertecd-main.go
@@ -43,10 +43,10 @@ func main() {
 	}
 
 	s := &scertecd.Server{
-		SetecClient: setec.Client{Server: *setecURL},
-		Domains:     strings.Split(*domains, ","),
-		ACMEContact: *acmeContact,
-		Prefix:      *prefix,
+		SetecClient:   setec.Client{Server: *setecURL},
+		PublicDomains: strings.Split(*domains, ","),
+		ACMEContact:   *acmeContact,
+		Prefix:        *prefix,
 	}
 	if *foreground {
 		if err := s.UpdateAll(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tailscale/scertec
 
-go 1.22.0
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go v1.44.267
@@ -9,12 +9,32 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.24.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
+	github.com/aws/aws-sdk-go-v2/config v1.26.5 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.16.16 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.47.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 // indirect
+	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/tink-crypto/tink-go/v2 v2.1.0 // indirect
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/protobuf v1.32.0 // indirect
 	tailscale.com v1.1.1-0.20240212200800-c42a4e407a9f // indirect
 )

--- a/scertecd/scertecd_test.go
+++ b/scertecd/scertecd_test.go
@@ -1,0 +1,143 @@
+package scertecd
+
+import (
+	"crypto/ed25519"
+	crand "crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log"
+	"math"
+	"math/big"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tailscale/setec/client/setec"
+	"github.com/tailscale/setec/setectest"
+)
+
+func rootCA(t *testing.T, orgName string) (privKey ed25519.PrivateKey, cert *x509.Certificate) {
+	t.Helper()
+
+	// create the test CA
+	caPub, caPriv, err := ed25519.GenerateKey(crand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := x509.Certificate{
+		SerialNumber: randSerial(t),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		Subject: pkix.Name{
+			CommonName:   "Test Root CA",
+			Organization: []string{orgName},
+		},
+		BasicConstraintsValid: true,
+	}
+	rootDER, err := x509.CreateCertificate(crand.Reader, &root, &root, caPub, caPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selfSigned, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return caPriv, selfSigned
+}
+
+func randSerial(t *testing.T) *big.Int {
+	t.Helper()
+	n, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func TestPrivateCARenewal(t *testing.T) {
+	rootPrivKey, rootCert := rootCA(t, "Tailscale Root CA")
+
+	pkb, err := x509.MarshalPKCS8PrivateKey(rootPrivKey)
+	if err != nil {
+		t.Fatalf("error marshaling root private key: %v", err)
+	}
+	privKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: pkb})
+	rootCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Raw})
+
+	// create setec test server with the root CA populated in the DB
+	db := setectest.NewDB(t, nil)
+	db.MustPut(db.Superuser, "test/scertec/roots/private-key", string(privKeyPEM))
+	db.MustPut(db.Superuser, "test/scertec/roots/certificate-latest", string(rootCertPEM))
+	ss := setectest.NewServer(t, db, nil)
+	hs := httptest.NewServer(ss.Mux)
+	defer hs.Close()
+	st := setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do}
+
+	// create the certUpdateCheck for the private domain
+	secName := "test/scertec/domains/foobar.tailscale.com/ECDSA"
+	cu := certUpdateCheck{
+		s: &Server{
+			SetecClient: st,
+			Prefix:      "test/scertec/",
+			Now:         time.Now,
+		},
+		dt: domainAndType{
+			domain:    "foobar.tailscale.com",
+			typ:       "ECDSA",
+			privateCA: true,
+		},
+		mu: sync.Mutex{},
+		lg: log.New(io.Discard, "", 0),
+		res: &certUpdateResult{
+			SecretName: secName,
+			CheckedAt:  time.Now(),
+		},
+	}
+
+	// perform a private CA renewal
+	if err := cu.privateCARenewal(t.Context(), secName); err != nil {
+		t.Fatalf("privateCARenewal error: %v", err)
+	}
+
+	// retrieve the key & certificate from setec
+	sec, err := st.Get(t.Context(), secName)
+	if err != nil {
+		t.Fatalf("error retrieving secret after renewal: %v", err)
+	}
+	if sec == nil || sec.Value == nil {
+		t.Fatal("got nil secret after renewal")
+	}
+
+	// validate the retrieved key/certificate
+	t.Logf("renewed secret value:\n%s", sec.Value)
+	meta, err := cu.s.parseCertMeta(sec.Value, true)
+	if err != nil {
+		t.Fatalf("error parsing renewed cert: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("got nil cert meta after renewal")
+	}
+	if meta.Leaf == nil {
+		t.Fatal("got nil Leaf after renewal")
+	}
+
+	// verify the leaf certificate is signed by the test root CA
+	roots := x509.NewCertPool()
+	if ok := roots.AppendCertsFromPEM(rootCertPEM); !ok {
+		t.Fatal("failed to append root certificate to pool")
+	}
+	opts := x509.VerifyOptions{
+		DNSName: "foobar.tailscale.com",
+		Roots:   roots,
+	}
+	if _, err := meta.Leaf.Verify(opts); err != nil {
+		t.Fatalf("failed to verify leaf certificate against root: %v", err)
+	}
+}


### PR DESCRIPTION
Extend scertec with support for issuing certificates using private roots stored in setec alongside requesting certificates the public Let's Encrypt issuer.

Updates tailscale/corp#28569